### PR TITLE
Fix service_associations output for lattice-service-network module

### DIFF
--- a/modules/lattice-service-network/outputs.tf
+++ b/modules/lattice-service-network/outputs.tf
@@ -66,7 +66,11 @@ output "service_associations" {
       status     = association.status
       created_by = association.created_by
 
-      service = association.service
+      service = association.service_identifier
+
+      domain        = one(association.dns_entry[*].domain_name)
+      zone_id       = one(association.dns_entry[*].hosted_zone_id)
+      custom_domain = association.custom_domain_name
     }
   }
 }


### PR DESCRIPTION
### :wave: Background
<!-- Please explain the background or motivation for this change. -->

- Fix service_associations output for lattice-service-network module