### PR TITLE
Support lambda_event_structure_version for lattice-lambda-target-group

### DIFF
--- a/examples/lattice-lambda-target-group/main.tf
+++ b/examples/lattice-lambda-target-group/main.tf
@@ -14,6 +14,8 @@ module "target_group" {
 
   name = "lambda-hello"
 
+  lambda_event_structure_version = "V2"
+
 
   ## Targets
   targets = [

--- a/modules/lattice-alb-target-group/README.md
+++ b/modules/lattice-alb-target-group/README.md
@@ -11,13 +11,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-alb-target-group/main.tf
+++ b/modules/lattice-alb-target-group/main.tf
@@ -27,8 +27,9 @@ locals {
 ###################################################
 
 # INFO: Not supported attributes
-# - `config.ip_address_type`
 # - `config.health_check`
+# - `config.ip_address_type`
+# - `config.lambda_event_structure_version`
 resource "aws_vpclattice_target_group" "this" {
   name = var.name
   type = "ALB"

--- a/modules/lattice-alb-target-group/versions.tf
+++ b/modules/lattice-alb-target-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-instance-target-group/README.md
+++ b/modules/lattice-instance-target-group/README.md
@@ -11,13 +11,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-instance-target-group/main.tf
+++ b/modules/lattice-instance-target-group/main.tf
@@ -28,6 +28,7 @@ locals {
 
 # INFO: Not supported attributes
 # - `config.ip_address_type`
+# - `config.lambda_event_structure_version`
 resource "aws_vpclattice_target_group" "this" {
   name = var.name
   type = "INSTANCE"

--- a/modules/lattice-instance-target-group/versions.tf
+++ b/modules/lattice-instance-target-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-ip-target-group/README.md
+++ b/modules/lattice-ip-target-group/README.md
@@ -11,13 +11,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-ip-target-group/main.tf
+++ b/modules/lattice-ip-target-group/main.tf
@@ -26,6 +26,8 @@ locals {
 # IP Target Group for VPC Lattice Service
 ###################################################
 
+# INFO: Not supported attributes
+# - `config.lambda_event_structure_version`
 resource "aws_vpclattice_target_group" "this" {
   name = var.name
   type = "IP"

--- a/modules/lattice-ip-target-group/versions.tf
+++ b/modules/lattice-ip-target-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-lambda-target-group/README.md
+++ b/modules/lattice-lambda-target-group/README.md
@@ -11,13 +11,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 
@@ -37,6 +37,7 @@ This module creates following resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the target group. The name must be unique within the account. The valid characters are a-z, 0-9, and hyphens (-). You can't use a hyphen as the first or last character, or immediately after another hyphen. | `string` | n/a | yes |
+| <a name="input_lambda_event_structure_version"></a> [lambda\_event\_structure\_version](#input\_lambda\_event\_structure\_version) | (Optional) The version of the event structure that the Lambda function receives. Valid values are `V1` are `V2`. Defaults to `V2`. | `string` | `"V2"` | no |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
@@ -51,6 +52,7 @@ This module creates following resources.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the target group. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of the target group. |
+| <a name="output_lambda_event_structure_version"></a> [lambda\_event\_structure\_version](#output\_lambda\_event\_structure\_version) | The version of the event structure that the Lambda function receives. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the target group. |
 | <a name="output_status"></a> [status](#output\_status) | The status of the target group. |
 | <a name="output_targets"></a> [targets](#output\_targets) | The list of targets of the target group.<br>    `name` - The name of the target. This value is only used internally within Terraform code.<br>    `lambda_function` - The Amazon Resource Name (ARN) of the target Lambda function. |

--- a/modules/lattice-lambda-target-group/main.tf
+++ b/modules/lattice-lambda-target-group/main.tf
@@ -20,10 +20,19 @@ locals {
 ###################################################
 
 # INFO: Not supported attributes
-# - `config`
+# - `config.health_check`
+# - `config.ip_address_type`
+# - `config.port`
+# - `config.protocol`
+# - `config.protocol_version`
+# - `config.vpc_identifier`
 resource "aws_vpclattice_target_group" "this" {
   name = var.name
   type = "LAMBDA"
+
+  config {
+    lambda_event_structure_version = var.lambda_event_structure_version
+  }
 
   timeouts {
     create = var.timeouts.create

--- a/modules/lattice-lambda-target-group/outputs.tf
+++ b/modules/lattice-lambda-target-group/outputs.tf
@@ -23,6 +23,11 @@ output "status" {
   value       = aws_vpclattice_target_group.this.status
 }
 
+output "lambda_event_structure_version" {
+  description = "The version of the event structure that the Lambda function receives."
+  value       = one(aws_vpclattice_target_group.this.config[*].lambda_event_structure_version)
+}
+
 output "targets" {
   description = <<EOF
   The list of targets of the target group.

--- a/modules/lattice-lambda-target-group/variables.tf
+++ b/modules/lattice-lambda-target-group/variables.tf
@@ -4,6 +4,18 @@ variable "name" {
   nullable    = false
 }
 
+variable "lambda_event_structure_version" {
+  description = "(Optional) The version of the event structure that the Lambda function receives. Valid values are `V1` are `V2`. Defaults to `V2`."
+  type        = string
+  default     = "V2"
+  nullable    = false
+
+  validation {
+    condition     = contains(["V1", "V2"], var.lambda_event_structure_version)
+    error_message = "Valid values for `lambda_event_structure_version` are `V1` and `V2`."
+  }
+}
+
 variable "targets" {
   description = <<EOF
   (Optional) A list of targets to add to the target group. Each value of `targets` block as defined below.

--- a/modules/lattice-lambda-target-group/versions.tf
+++ b/modules/lattice-lambda-target-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-service-listener/README.md
+++ b/modules/lattice-service-listener/README.md
@@ -11,13 +11,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-service-listener/versions.tf
+++ b/modules/lattice-service-listener/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-service-network/README.md
+++ b/modules/lattice-service-network/README.md
@@ -15,13 +15,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-service-network/versions.tf
+++ b/modules/lattice-service-network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-service/README.md
+++ b/modules/lattice-service/README.md
@@ -16,13 +16,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-service/versions.tf
+++ b/modules/lattice-service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-shared-service-network/README.md
+++ b/modules/lattice-shared-service-network/README.md
@@ -11,13 +11,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-shared-service-network/versions.tf
+++ b/modules/lattice-shared-service-network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }

--- a/modules/lattice-shared-service/README.md
+++ b/modules/lattice-shared-service/README.md
@@ -10,13 +10,13 @@ This module creates following resources.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.17.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.22.0 |
 
 ## Modules
 

--- a/modules/lattice-shared-service/versions.tf
+++ b/modules/lattice-shared-service/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.12"
+      version = ">= 5.21"
     }
   }
 }


### PR DESCRIPTION
### :wave: Background
<!-- Please explain the background or motivation for this change. -->

- Support lambda_event_structure_version for lattice-lambda-target-group

#### :link: Related Issues
<!-- Please share any issues related to this change. -->

- https://github.com/hashicorp/terraform-provider-aws/pull/33804