### PR TITLE
feat: improve how to use resource_group in modules

### DIFF
--- a/modules/dx-connection/outputs.tf
+++ b/modules/dx-connection/outputs.tf
@@ -76,3 +76,19 @@ output "encryption" {
     status         = aws_dx_connection.this.port_encryption_status
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/dx-connection/resource-group.tf
+++ b/modules/dx-connection/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/dx-connection/variables.tf
+++ b/modules/dx-connection/variables.tf
@@ -74,23 +74,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/dx-private-virtual-interface/outputs.tf
+++ b/modules/dx-private-virtual-interface/outputs.tf
@@ -105,3 +105,19 @@ output "router_configuration" {
     output_path = var.router_configuration.output_path
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/dx-private-virtual-interface/resource-group.tf
+++ b/modules/dx-private-virtual-interface/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/dx-private-virtual-interface/variables.tf
+++ b/modules/dx-private-virtual-interface/variables.tf
@@ -132,23 +132,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/lattice-alb-target-group/outputs.tf
+++ b/modules/lattice-alb-target-group/outputs.tf
@@ -59,3 +59,19 @@ output "targets" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-alb-target-group/resource-group.tf
+++ b/modules/lattice-alb-target-group/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-alb-target-group/variables.tf
+++ b/modules/lattice-alb-target-group/variables.tf
@@ -112,23 +112,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/lattice-instance-target-group/outputs.tf
+++ b/modules/lattice-instance-target-group/outputs.tf
@@ -91,3 +91,19 @@ output "targets" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-instance-target-group/resource-group.tf
+++ b/modules/lattice-instance-target-group/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-instance-target-group/variables.tf
+++ b/modules/lattice-instance-target-group/variables.tf
@@ -186,23 +186,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/lattice-ip-target-group/outputs.tf
+++ b/modules/lattice-ip-target-group/outputs.tf
@@ -96,3 +96,19 @@ output "targets" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-ip-target-group/resource-group.tf
+++ b/modules/lattice-ip-target-group/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-ip-target-group/variables.tf
+++ b/modules/lattice-ip-target-group/variables.tf
@@ -198,23 +198,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/lattice-lambda-target-group/outputs.tf
+++ b/modules/lattice-lambda-target-group/outputs.tf
@@ -42,3 +42,19 @@ output "targets" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-lambda-target-group/resource-group.tf
+++ b/modules/lattice-lambda-target-group/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-lambda-target-group/variables.tf
+++ b/modules/lattice-lambda-target-group/variables.tf
@@ -64,23 +64,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/lattice-service-listener/outputs.tf
+++ b/modules/lattice-service-listener/outputs.tf
@@ -90,8 +90,7 @@ output "rules" {
       }
 
       action = {
-        type       = rule.action_type
-        parameters = rule.action_parameters
+        type = rule.action_type
         parameters = {
           "FIXED_RESPONSE" = one(aws_vpclattice_listener_rule.this[rule.priority].action[0].fixed_response[*])
           "FORWARD" = {
@@ -111,4 +110,20 @@ output "created_at" {
 output "updated_at" {
   description = "Date and time that the listener was last updated, specified in ISO-8601 format."
   value       = aws_vpclattice_listener.this.last_updated_at
+}
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
 }

--- a/modules/lattice-service-listener/resource-group.tf
+++ b/modules/lattice-service-listener/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-service-listener/variables.tf
+++ b/modules/lattice-service-listener/variables.tf
@@ -218,23 +218,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/lattice-service-network/outputs.tf
+++ b/modules/lattice-service-network/outputs.tf
@@ -133,3 +133,19 @@ output "sharing" {
     shares = module.share
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-service-network/resource-group.tf
+++ b/modules/lattice-service-network/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-service-network/variables.tf
+++ b/modules/lattice-service-network/variables.tf
@@ -188,26 +188,8 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
-}
 
 
 ###################################################
@@ -227,5 +209,21 @@ variable "shares" {
     tags = optional(map(string), {})
   }))
   default  = []
+  nullable = false
+}
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
   nullable = false
 }

--- a/modules/lattice-service/listeners.tf
+++ b/modules/lattice-service/listeners.tf
@@ -21,8 +21,10 @@ module "listener" {
 
   rules = try(each.value.rules, [])
 
-  resource_group_enabled = false
-  module_tags_enabled    = false
+  resource_group = {
+    enabled = false
+  }
+  module_tags_enabled = false
 
   tags = merge(
     local.module_tags,

--- a/modules/lattice-service/outputs.tf
+++ b/modules/lattice-service/outputs.tf
@@ -147,3 +147,19 @@ output "sharing" {
     shares = module.share
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-service/resource-group.tf
+++ b/modules/lattice-service/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-service/variables.tf
+++ b/modules/lattice-service/variables.tf
@@ -276,26 +276,8 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
-}
 
 
 ###################################################
@@ -315,5 +297,21 @@ variable "shares" {
     tags = optional(map(string), {})
   }))
   default  = []
+  nullable = false
+}
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
   nullable = false
 }

--- a/modules/lattice-shared-service-network/outputs.tf
+++ b/modules/lattice-shared-service-network/outputs.tf
@@ -79,3 +79,19 @@ output "updated_at" {
   description = "Date and time that the service network was last updated, specified in ISO-8601 format."
   value       = data.aws_vpclattice_service_network.this.last_updated_at
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-shared-service-network/resource-group.tf
+++ b/modules/lattice-shared-service-network/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-shared-service-network/variables.tf
+++ b/modules/lattice-shared-service-network/variables.tf
@@ -55,23 +55,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/lattice-shared-service/outputs.tf
+++ b/modules/lattice-shared-service/outputs.tf
@@ -63,3 +63,19 @@ output "service_network_associations" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/lattice-shared-service/resource-group.tf
+++ b/modules/lattice-shared-service/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/lattice-shared-service/variables.tf
+++ b/modules/lattice-shared-service/variables.tf
@@ -39,23 +39,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/reachability-analyzer-path/outputs.tf
+++ b/modules/reachability-analyzer-path/outputs.tf
@@ -66,3 +66,19 @@ output "analyses" {
     }
   ]
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/reachability-analyzer-path/resource-group.tf
+++ b/modules/reachability-analyzer-path/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/reachability-analyzer-path/variables.tf
+++ b/modules/reachability-analyzer-path/variables.tf
@@ -80,23 +80,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/vpc-endpoint-service/outputs.tf
+++ b/modules/vpc-endpoint-service/outputs.tf
@@ -93,3 +93,19 @@ output "connection_notifications" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/vpc-endpoint-service/resource-group.tf
+++ b/modules/vpc-endpoint-service/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/vpc-endpoint-service/variables.tf
+++ b/modules/vpc-endpoint-service/variables.tf
@@ -108,23 +108,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/vpc-gateway-endpoint/outputs.tf
+++ b/modules/vpc-gateway-endpoint/outputs.tf
@@ -56,3 +56,19 @@ output "route_tables" {
   EOF
   value       = aws_vpc_endpoint_route_table_association.this[*].route_table_id
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/vpc-gateway-endpoint/resource-group.tf
+++ b/modules/vpc-gateway-endpoint/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/vpc-gateway-endpoint/variables.tf
+++ b/modules/vpc-gateway-endpoint/variables.tf
@@ -67,23 +67,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/vpc-interface-endpoint/outputs.tf
+++ b/modules/vpc-interface-endpoint/outputs.tf
@@ -96,3 +96,19 @@ output "connection_notifications" {
     }
   }
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/vpc-interface-endpoint/resource-group.tf
+++ b/modules/vpc-interface-endpoint/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/vpc-interface-endpoint/variables.tf
+++ b/modules/vpc-interface-endpoint/variables.tf
@@ -179,23 +179,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/vpc-peering-accepter/main.tf
+++ b/modules/vpc-peering-accepter/main.tf
@@ -15,18 +15,15 @@ locals {
 }
 
 data "aws_caller_identity" "this" {}
-data "aws_region" "this" {}
 
 data "aws_vpc_peering_connection" "this" {
   id = var.peering_connection.id
 
   vpc_id     = var.peering_connection.requester_vpc.id
-  region     = var.peering_connection.requester_vpc.region
   owner_id   = var.peering_connection.requester_vpc.account
   cidr_block = var.peering_connection.requester_vpc.ipv4_cidr
 
   peer_vpc_id     = var.peering_connection.accepter_vpc.id
-  peer_region     = data.aws_region.this.name
   peer_owner_id   = data.aws_caller_identity.this.account_id
   peer_cidr_block = var.peering_connection.accepter_vpc.ipv4_cidr
 }

--- a/modules/vpc-peering-accepter/outputs.tf
+++ b/modules/vpc-peering-accepter/outputs.tf
@@ -27,3 +27,19 @@ output "allow_remote_vpc_dns_resolution" {
   description = "Whether to allow a accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC."
   value       = var.allow_remote_vpc_dns_resolution
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/vpc-peering-accepter/resource-group.tf
+++ b/modules/vpc-peering-accepter/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/vpc-peering-accepter/variables.tf
+++ b/modules/vpc-peering-accepter/variables.tf
@@ -60,23 +60,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/vpc-peering-accepter/variables.tf
+++ b/modules/vpc-peering-accepter/variables.tf
@@ -60,9 +60,6 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-
-
-
 variable "resource_group" {
   description = <<EOF
   (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.

--- a/modules/vpc-peering-requester/main.tf
+++ b/modules/vpc-peering-requester/main.tf
@@ -20,7 +20,7 @@ data "aws_region" "this" {}
 locals {
   requester_vpc = {
     id      = var.requester_vpc.id
-    region  = data.aws_region.this.name
+    region  = data.aws_region.this.region
     account = data.aws_caller_identity.this.account_id
   }
   accepter_vpc = {

--- a/modules/vpc-peering-requester/outputs.tf
+++ b/modules/vpc-peering-requester/outputs.tf
@@ -37,3 +37,19 @@ output "allow_remote_vpc_dns_resolution" {
   description = "Whether to allow a requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC."
   value       = var.allow_remote_vpc_dns_resolution
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/vpc-peering-requester/resource-group.tf
+++ b/modules/vpc-peering-requester/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,12 +12,12 @@ locals {
 
 module "resource_group" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/vpc-peering-requester/variables.tf
+++ b/modules/vpc-peering-requester/variables.tf
@@ -58,23 +58,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }

--- a/modules/vpc-peering/main.tf
+++ b/modules/vpc-peering/main.tf
@@ -41,12 +41,12 @@ data "aws_region" "accepter" {
 locals {
   requester_vpc = {
     id      = var.requester_vpc.id
-    region  = data.aws_region.requester.name
+    region  = data.aws_region.requester.region
     account = data.aws_caller_identity.requester.account_id
   }
   accepter_vpc = {
     id      = var.accepter_vpc.id
-    region  = data.aws_region.accepter.name
+    region  = data.aws_region.accepter.region
     account = data.aws_caller_identity.accepter.account_id
   }
 }

--- a/modules/vpc-peering/outputs.tf
+++ b/modules/vpc-peering/outputs.tf
@@ -42,3 +42,19 @@ output "accepter_options" {
   description = "The accepter options of the VPC Peering Connection."
   value       = var.accepter_options
 }
+
+output "resource_group" {
+  description = "The resource group created to manage resources in this module."
+  value = merge(
+    {
+      enabled = var.resource_group.enabled && var.module_tags_enabled
+    },
+    (var.resource_group.enabled && var.module_tags_enabled
+      ? {
+        arn  = module.resource_group[0].arn
+        name = module.resource_group[0].name
+      }
+      : {}
+    )
+  )
+}

--- a/modules/vpc-peering/outputs.tf
+++ b/modules/vpc-peering/outputs.tf
@@ -42,19 +42,3 @@ output "accepter_options" {
   description = "The accepter options of the VPC Peering Connection."
   value       = var.accepter_options
 }
-
-output "resource_group" {
-  description = "The resource group created to manage resources in this module."
-  value = merge(
-    {
-      enabled = var.resource_group.enabled && var.module_tags_enabled
-    },
-    (var.resource_group.enabled && var.module_tags_enabled
-      ? {
-        arn  = module.resource_group[0].arn
-        name = module.resource_group[0].name
-      }
-      : {}
-    )
-  )
-}

--- a/modules/vpc-peering/resource-group.tf
+++ b/modules/vpc-peering/resource-group.tf
@@ -1,6 +1,6 @@
 locals {
-  resource_group_name = (var.resource_group_name != ""
-    ? var.resource_group_name
+  resource_group_name = (var.resource_group.name != ""
+    ? var.resource_group.name
     : join(".", [
       local.metadata.package,
       local.metadata.module,
@@ -12,16 +12,16 @@ locals {
 
 module "resource_group_requester" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
   providers = {
     aws = aws.requester
   }
 
-  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+  count = (var.resource_group.enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags
@@ -36,14 +36,14 @@ module "resource_group_requester" {
 
 module "resource_group_accepter" {
   source  = "tedilabs/misc/aws//modules/resource-group"
-  version = "~> 0.10.0"
+  version = "~> 0.12.0"
 
   providers = {
     aws = aws.accepter
   }
 
   count = (alltrue([
-    var.resource_group_enabled,
+    var.resource_group.enabled,
     var.module_tags_enabled,
     anytrue([
       local.requester_vpc.region != local.accepter_vpc.region,
@@ -52,7 +52,7 @@ module "resource_group_accepter" {
   ]) ? 1 : 0)
 
   name        = local.resource_group_name
-  description = var.resource_group_description
+  description = var.resource_group.description
 
   query = {
     resource_tags = local.module_tags

--- a/modules/vpc-peering/variables.tf
+++ b/modules/vpc-peering/variables.tf
@@ -73,9 +73,6 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-
-
-
 variable "resource_group" {
   description = <<EOF
   (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.

--- a/modules/vpc-peering/variables.tf
+++ b/modules/vpc-peering/variables.tf
@@ -73,23 +73,21 @@ variable "module_tags_enabled" {
 # Resource Group
 ###################################################
 
-variable "resource_group_enabled" {
-  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
-  type        = bool
-  default     = true
-  nullable    = false
-}
 
-variable "resource_group_name" {
-  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
-  type        = string
-  default     = ""
-  nullable    = false
-}
 
-variable "resource_group_description" {
-  description = "(Optional) The description of Resource Group."
-  type        = string
-  default     = "Managed by Terraform."
-  nullable    = false
+
+variable "resource_group" {
+  description = <<EOF
+  (Optional) A configurations of Resource Group for this module. `resource_group` as defined below.
+    (Optional) `enabled` - Whether to create Resource Group to find and group AWS resources which are created by this module. Defaults to `true`.
+    (Optional) `name` - The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. If not provided, a name will be generated using the module name and instance name.
+    (Optional) `description` - The description of Resource Group. Defaults to `Managed by Terraform.`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "Managed by Terraform.")
+  })
+  default  = {}
+  nullable = false
 }


### PR DESCRIPTION
## Summary
Update resource group configuration to use object-based pattern.

## Changes
- Update module version from ~> 0.10.0 to ~> 0.12.0
- Replace individual resource_group_* variables with single object variable  
- Update all references to use var.resource_group.* structure
- Add resource_group output to each module

## Modules Updated
- dx-connection
- dx-private-virtual-interface
- lattice-alb-target-group
- lattice-instance-target-group
- lattice-ip-target-group
- lattice-lambda-target-group
- lattice-service
- lattice-service-listener
- lattice-service-network
- lattice-shared-service
- lattice-shared-service-network
- reachability-analyzer-path
- vpc-endpoint-service
- vpc-gateway-endpoint
- vpc-interface-endpoint
- vpc-peering
- vpc-peering-accepter
- vpc-peering-requester

## Test Plan
- [ ] Review variable changes
- [ ] Verify resource-group module references are correct  
- [ ] Check outputs are properly formatted