### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/lattice-alb-target-group/alb.tf
+++ b/examples/lattice-alb-target-group/alb.tf
@@ -4,7 +4,7 @@
 
 module "alb" {
   source  = "tedilabs/load-balancer/aws//modules/alb"
-  version = "~> 1.3.0"
+  version = "~> 1.5.0"
 
   name = "alb-for-vpc-lattice"
 
@@ -14,7 +14,7 @@ module "alb" {
   network_mapping = {
     for az, subnet in data.aws_subnet.default :
     az => {
-      subnet_id = subnet.id
+      subnet = subnet.id
     }
   }
 
@@ -22,7 +22,7 @@ module "alb" {
     name        = "alb-for-vpc-lattice"
     description = "Managed by Terraform."
 
-    ingress_cidrs = ["10.0.0.0/8", "172.31.0.0/16"]
+    listener_ingress_ipv4_cidrs = ["10.0.0.0/8", "172.31.0.0/16"]
   }
   security_groups = []
 

--- a/examples/lattice-alb-target-group/main.tf
+++ b/examples/lattice-alb-target-group/main.tf
@@ -21,7 +21,7 @@ data "aws_subnet" "default" {
 module "target_group" {
   source = "../../modules/lattice-alb-target-group"
   # source  = "tedilabs/vpc-connectivity/aws//modules/lattice-alb-target-group"
-  # version = "~> 0.2.0"
+  # version = "~> 0.9.0"
 
   name = "alb-hello"
 

--- a/examples/lattice-instance-target-group/main.tf
+++ b/examples/lattice-instance-target-group/main.tf
@@ -21,7 +21,7 @@ data "aws_subnet" "default" {
 module "target_group" {
   source = "../../modules/lattice-instance-target-group"
   # source  = "tedilabs/vpc-connectivity/aws//modules/lattice-instance-target-group"
-  # version = "~> 0.2.0"
+  # version = "~> 0.9.0"
 
   name = "instance-hello"
 

--- a/examples/lattice-ip-target-group/main.tf
+++ b/examples/lattice-ip-target-group/main.tf
@@ -21,7 +21,7 @@ data "aws_subnet" "default" {
 module "target_group" {
   source = "../../modules/lattice-ip-target-group"
   # source  = "tedilabs/vpc-connectivity/aws//modules/lattice-ip-target-group"
-  # version = "~> 0.2.0"
+  # version = "~> 0.9.0"
 
   name = "ip-hello"
 

--- a/examples/lattice-lambda-target-group/main.tf
+++ b/examples/lattice-lambda-target-group/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "target_group" {
   source = "../../modules/lattice-lambda-target-group"
   # source  = "tedilabs/vpc-connectivity/aws//modules/lattice-lambda-target-group"
-  # version = "~> 0.2.0"
+  # version = "~> 0.9.0"
 
   name = "lambda-hello"
 

--- a/examples/lattice-service-network-simple/main.tf
+++ b/examples/lattice-service-network-simple/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "service_network" {
   source = "../../modules/lattice-service-network"
   # source  = "tedilabs/vpc-connectivity/aws//modules/lattice-service-network"
-  # version = "~> 0.2.0"
+  # version = "~> 0.9.0"
 
   name      = "test"
   auth_type = "NONE"

--- a/examples/reachability-analyzer/main.tf
+++ b/examples/reachability-analyzer/main.tf
@@ -20,7 +20,7 @@ data "aws_internet_gateway" "default" {
 module "reachability_analyzer_path__success" {
   source = "../../modules/reachability-analyzer-path"
   # source  = "tedilabs/vpc-connectivity/aws//modules/reachability-analyzer-path"
-  # version = "~> 0.1.0"
+  # version = "~> 0.9.0"
 
   name = "test-success"
 
@@ -47,7 +47,7 @@ module "reachability_analyzer_path__success" {
 module "reachability_analyzer_path__fail" {
   source = "../../modules/reachability-analyzer-path"
   # source  = "tedilabs/vpc-connectivity/aws//modules/reachability-analyzer-path"
-  # version = "~> 0.1.0"
+  # version = "~> 0.9.0"
 
   name = "test-fail"
 
@@ -95,7 +95,7 @@ data "aws_ami" "ubuntu" {
 
 module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 0.27.0"
+  version = "~> 1.2.0"
 
   name = "reachability-analyzer-test"
 
@@ -103,20 +103,18 @@ module "security_group" {
 
   ingress_rules = [
     {
-      id          = "http/all"
-      protocol    = "tcp"
-      from_port   = 80
-      to_port     = 80
-      cidr_blocks = ["0.0.0.0/0"]
+      id         = "http/all"
+      protocol   = "tcp"
+      from_port  = 80
+      to_port    = 80
+      ipv4_cidrs = ["0.0.0.0/0"]
     }
   ]
   egress_rules = [
     {
-      id          = "all/all"
-      protocol    = "-1"
-      from_port   = 0
-      to_port     = 0
-      cidr_blocks = ["0.0.0.0/0"]
+      id         = "all/all"
+      protocol   = "-1"
+      ipv4_cidrs = ["0.0.0.0/0"]
     }
   ]
 

--- a/modules/lattice-service-network/README.md
+++ b/modules/lattice-service-network/README.md
@@ -28,7 +28,7 @@ This module creates following resources.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
-| <a name="module_share"></a> [share](#module\_share) | tedilabs/account/aws//modules/ram-share | ~> 0.27.0 |
+| <a name="module_share"></a> [share](#module\_share) | tedilabs/organization/aws//modules/ram-share | ~> 0.7.0 |
 
 ## Resources
 

--- a/modules/lattice-service-network/ram-share.tf
+++ b/modules/lattice-service-network/ram-share.tf
@@ -1,28 +1,39 @@
+locals {
+  ram_share_name_prefix = join(".", [
+    "vpc-lattice",
+    "service-network",
+    replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
+  ])
+}
+
+
 ###################################################
 # Resource Sharing by RAM (Resource Access Manager)
 ###################################################
 
 module "share" {
-  source  = "tedilabs/account/aws//modules/ram-share"
-  version = "~> 0.27.0"
+  source  = "tedilabs/organization/aws//modules/ram-share"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :
     share.name => share
   }
 
-  name = "vpc-lattice.service-network.${var.name}.${each.key}"
+  name = "${local.ram_share_name_prefix}.${each.key}"
 
-  resources = [
-    aws_vpclattice_service_network.this.arn
-  ]
+  resources = {
+    (var.name) = aws_vpclattice_service_network.this.arn,
+  }
   permissions = each.value.permissions
 
   external_principals_allowed = each.value.external_principals_allowed
   principals                  = each.value.principals
 
-  resource_group_enabled = false
-  module_tags_enabled    = false
+  resource_group = {
+    enabled = false
+  }
+  module_tags_enabled = false
 
   tags = merge(
     local.module_tags,

--- a/modules/lattice-service/README.md
+++ b/modules/lattice-service/README.md
@@ -30,7 +30,7 @@ This module creates following resources.
 |------|--------|---------|
 | <a name="module_listener"></a> [listener](#module\_listener) | ../lattice-service-listener | n/a |
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
-| <a name="module_share"></a> [share](#module\_share) | tedilabs/account/aws//modules/ram-share | ~> 0.27.0 |
+| <a name="module_share"></a> [share](#module\_share) | tedilabs/organization/aws//modules/ram-share | ~> 0.7.0 |
 
 ## Resources
 

--- a/modules/lattice-service/ram-share.tf
+++ b/modules/lattice-service/ram-share.tf
@@ -1,28 +1,39 @@
+locals {
+  ram_share_name_prefix = join(".", [
+    "vpc-lattice",
+    "service",
+    replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
+  ])
+}
+
+
 ###################################################
 # Resource Sharing by RAM (Resource Access Manager)
 ###################################################
 
 module "share" {
-  source  = "tedilabs/account/aws//modules/ram-share"
-  version = "~> 0.27.0"
+  source  = "tedilabs/organization/aws//modules/ram-share"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :
     share.name => share
   }
 
-  name = "vpc-lattice.service.${var.name}.${each.key}"
+  name = "${local.ram_share_name_prefix}.${each.key}"
 
-  resources = [
-    aws_vpclattice_service.this.arn
-  ]
+  resources = {
+    (var.name) = aws_vpclattice_service.this.arn,
+  }
   permissions = each.value.permissions
 
   external_principals_allowed = each.value.external_principals_allowed
   principals                  = each.value.principals
 
-  resource_group_enabled = false
-  module_tags_enabled    = false
+  resource_group = {
+    enabled = false
+  }
+  module_tags_enabled = false
 
   tags = merge(
     local.module_tags,


### PR DESCRIPTION
## What & why

The `version` constraints on sibling tedilabs child modules had drifted several majors behind their latest releases, and one of them — `tedilabs/account/aws//modules/ram-share` — no longer exists at all. This PR realigns every constraint to the house `~> MAJOR.MINOR.0` convention, migrates the two RAM-share call sites to the module's new home, and updates the calling code in this repo to match the new interfaces.

Two of the three active bumps are genuinely breaking upstream, so this is not a mechanical version-string change: the ALB and security-group call sites in `examples/`, and both `modules/*/ram-share.tf` call sites, were rewritten. **Consumers of `modules/lattice-service` and `modules/lattice-service-network` who use `var.shares` will see resource-share associations replaced — see "Breaking change for consumers" below.**

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/load-balancer/aws//modules/alb` | `examples/lattice-alb-target-group/alb.tf` | `~> 1.3.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/network/aws//modules/security-group` | `examples/reachability-analyzer/main.tf` | `~> 0.27.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/account/aws//modules/ram-share` → **`tedilabs/organization/aws//modules/ram-share`** | `modules/lattice-service-network/ram-share.tf` | `~> 0.27.0` | `~> 0.7.0` | `v0.7.5` |
| `tedilabs/account/aws//modules/ram-share` → **`tedilabs/organization/aws//modules/ram-share`** | `modules/lattice-service/ram-share.tf` | `~> 0.27.0` | `~> 0.7.0` | `v0.7.5` |

### Example docs (commented registry alternatives)

These are the commented-out registry equivalents next to the live `../../modules/x` local sources. `source` is unchanged (this repo's registry namespace did not move); only `version` was bumped.

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/vpc-connectivity/aws//modules/lattice-alb-target-group` | `examples/lattice-alb-target-group/main.tf:24` | `~> 0.2.0` | `~> 0.9.0` | `v0.9.0` |
| `tedilabs/vpc-connectivity/aws//modules/lattice-instance-target-group` | `examples/lattice-instance-target-group/main.tf:24` | `~> 0.2.0` | `~> 0.9.0` | `v0.9.0` |
| `tedilabs/vpc-connectivity/aws//modules/lattice-ip-target-group` | `examples/lattice-ip-target-group/main.tf:24` | `~> 0.2.0` | `~> 0.9.0` | `v0.9.0` |
| `tedilabs/vpc-connectivity/aws//modules/lattice-lambda-target-group` | `examples/lattice-lambda-target-group/main.tf:13` | `~> 0.2.0` | `~> 0.9.0` | `v0.9.0` |
| `tedilabs/vpc-connectivity/aws//modules/lattice-service-network` | `examples/lattice-service-network-simple/main.tf:13` | `~> 0.2.0` | `~> 0.9.0` | `v0.9.0` |
| `tedilabs/vpc-connectivity/aws//modules/reachability-analyzer-path` | `examples/reachability-analyzer/main.tf:23` | `~> 0.1.0` | `~> 0.9.0` | `v0.9.0` |
| `tedilabs/vpc-connectivity/aws//modules/reachability-analyzer-path` | `examples/reachability-analyzer/main.tf:50` | `~> 0.1.0` | `~> 0.9.0` | `v0.9.0` |

## Interface changes between the old and new versions

### 1. `ram-share`: the module was deleted, not upgraded

**Verdict: ACTION_REQUIRED — module migration, not a version bump.**

Compare URL: https://github.com/tedilabs/terraform-aws-account/compare/v0.27.0...v0.33.10

`modules/ram-share` was **removed outright** from `terraform-aws-account` by commit `e8e500a` *"Migrate org and sso related modules to terraform-aws-organization (#105)"*, first released in **v0.29.0**. It is therefore absent from every `0.29.x`+ release including `v0.33.10`. Verified directly against the tags: the directory is present at `v0.28.3` and gone at `v0.29.0` and `v0.33.10`.

The practical consequence is important: **bumping this constraint to `~> 0.33.0` (or `~> 0.33.10`) does not work — `terraform init` fails to find the submodule.** See "Supersedes" below.

The replacement is `tedilabs/organization/aws//modules/ram-share`, and this PR adopts the exact pattern that `terraform-aws-network` (`modules/security-group/ram-share.tf`, `modules/subnet-group/ram-share.tf`) and `terraform-aws-transit-gateway` (`modules/transit-gateway/ram-share.tf`, `modules/multicast-domain/ram-share.tf`) already use for this same migration.

Compare URL for the replacement module's own drift (for reference): https://github.com/tedilabs/terraform-aws-organization/compare/v0.5.6...v0.7.5 — **NO_INTERFACE_CHANGE**; the `modules/ram-share` tree is byte-identical at both tags. This PR pins `~> 0.7.0` rather than the siblings' `~> 0.5.0` simply because `~> 0.7.0` is current; the interface is the same.

Interface deltas absorbed, old (`account` v0.27.0) → new (`organization` v0.7.5):

| Change | Old | New |
|---|---|---|
| Module address | `tedilabs/account/aws//modules/ram-share` | `tedilabs/organization/aws//modules/ram-share` |
| `resources` | `list(string)`, default `[]` | `map(string)`, default `{}` |
| `resource_group_enabled` / `resource_group_name` / `resource_group_description` | three flat variables | folded into `resource_group = { enabled, name, description }` |
| `region` | — | added, `string`, default `null` (not set by this repo — see follow-ups) |
| `permissions` | always prefixed with `arn:aws:ram::aws:permission/` | now also accepts a full permission ARN; bare names behave identically |
| Outputs | `name`, `id`, `arn`, `external_principals_allowed`, `permissions`, `principals`, `resources` | same, plus `region` and `resource_group` — nothing removed or renamed |
| Terraform floor | `>= 1.3` | `>= 1.12` |
| `hashicorp/aws` floor | `>= 4.29` | `>= 6.12` |

Calling-code changes made in both `modules/lattice-service/ram-share.tf` and `modules/lattice-service-network/ram-share.tf`:

```diff
-  source  = "tedilabs/account/aws//modules/ram-share"
-  version = "~> 0.27.0"
+  source  = "tedilabs/organization/aws//modules/ram-share"
+  version = "~> 0.7.0"

-  name = "vpc-lattice.service.${var.name}.${each.key}"
+  name = "${local.ram_share_name_prefix}.${each.key}"

-  resources = [
-    aws_vpclattice_service.this.arn
-  ]
+  resources = {
+    (var.name) = aws_vpclattice_service.this.arn,
+  }

-  resource_group_enabled = false
-  module_tags_enabled    = false
+  resource_group = {
+    enabled = false
+  }
+  module_tags_enabled = false
```

plus the new `locals` block matching the sibling repos:

```hcl
locals {
  ram_share_name_prefix = join(".", [
    "vpc-lattice",
    "service",   # "service-network" in the other module
    replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
  ])
}
```

#### Breaking change for consumers

**1. RAM resource associations are destroyed and recreated.** The child module changed `for_each = toset(var.resources)` to `for_each = var.resources`, so `aws_ram_resource_association.this` is re-keyed from the resource ARN to the caller-chosen map key — here, `var.name`. Any consumer of `modules/lattice-service` or `modules/lattice-service-network` that passes `shares` will see a plan like:

```
module.<x>.module.share["<share>"].aws_ram_resource_association.this["arn:aws:vpc-lattice:...:service/svc-abc"]  will be destroyed
module.<x>.module.share["<share>"].aws_ram_resource_association.this["<var.name>"]                              will be created
```

This is accepted and intentional — it is the same churn `terraform-aws-network` and `terraform-aws-transit-gateway` already took when they migrated. Consumers who want to avoid the replacement can pre-seed state:

```
terraform state mv \
  'module.<x>.module.share["<share>"].aws_ram_resource_association.this["<old-arn>"]' \
  'module.<x>.module.share["<share>"].aws_ram_resource_association.this["<var.name>"]'
```

**2. Share names change only if `var.name` contains characters outside `[a-zA-Z0-9_.-]`.** The name is still `vpc-lattice.<kind>.<name>.<share-key>`; the only difference is that `var.name` now passes through `replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-")`. For all conventional names the resulting share name is byte-identical. This sanitiser was adopted because all four existing sibling call sites use it consistently.

**3. Resource-share tags change in place.** The child module's `module.terraform.io/package` tag value becomes `terraform-aws-organization`, so `aws_ram_resource_share` tags update in place. (`module_tags_enabled = false` is passed here, so this only affects the child module's own tagging of the share, not this repo's `local.module_tags`.)

### 2. `tedilabs/load-balancer/aws//modules/alb` v1.3.0 → v1.5.0

**Verdict: ACTION_REQUIRED.**

Compare URL: https://github.com/tedilabs/terraform-aws-load-balancer/compare/v1.3.0...v1.5.0

- **Removed variables:** `access_log_enabled`, `access_log_s3_bucket`, `access_log_s3_key_prefix` (→ `access_log` object); `resource_group_enabled`, `resource_group_name`, `resource_group_description` (→ `resource_group` object).
- **Added variables:** `region`, `access_log`, `cross_zone_load_balancing_enabled` (validated to accept only `true`), `tls_negotiation_headers_enabled`, `xff_header`, `timeouts`, `resource_group`.
- **Retyped/renamed:** `network_mapping` went from `map(map(string))` to `map(object({ subnet = string }))` — inner `subnet_id` renamed to `subnet`. `default_security_group` went from `any` to a **closed** object; the four ingress attributes were renamed `ingress_cidrs`→`listener_ingress_ipv4_cidrs`, `ingress_ipv6_cidrs`→`listener_ingress_ipv6_cidrs`, `ingress_prefix_lists`→`listener_ingress_prefix_lists`, `ingress_security_groups`→`listener_ingress_security_groups`, and `enabled`/`ingress_rules`/`egress_rules` were added. `security_groups` went `set(string)`→`list(string)` (not breaking).
- **`listeners` is still typed `any`, and that hides two changes** that `terraform validate` cannot catch: the flat `tls_certificate` / `tls_security_policy` / `tls_additional_certificates` keys moved into a nested `tls = { certificate, security_policy, additional_certificates }` object and, because every read is `try()`-wrapped, **the old flat names are silently discarded**. Separately, `default_action_parameters` is now read without `try()`, making it de-facto required on every listener element.
- **Outputs:** `available_availability_zone_ids` removed (no replacement). `default_security_group` retyped from an object to a bare security group ID string (and is `null` when disabled). `access_log` keys reshaped to `{ enabled, s3_bucket = { name, key_prefix } }`. `network_mapping` values reshaped `{ subnet_id, cidr_block }` → `{ subnet, ipv4_cidr, ipv6_cidr }`. Added: `region`, `resource_group`.
- **Version floors:** Terraform `>= 1.3` → `>= 1.12`; `hashicorp/aws` `>= 4.25` → `>= 6.22` (two provider majors).

Calling code changed in `examples/lattice-alb-target-group/alb.tf`:

```diff
   network_mapping = {
     for az, subnet in data.aws_subnet.default :
     az => {
-      subnet_id = subnet.id
+      subnet = subnet.id
     }
   }

   default_security_group = {
     name        = "alb-for-vpc-lattice"
     description = "Managed by Terraform."

-    ingress_cidrs = ["10.0.0.0/8", "172.31.0.0/16"]
+    listener_ingress_ipv4_cidrs = ["10.0.0.0/8", "172.31.0.0/16"]
   }
```

The whole example directory was explicitly grepped for every stale name in the list above — `tls_certificate`, `tls_security_policy`, `tls_additional_certificates`, `subnet_id`, `ingress_cidrs`, `ingress_ipv6_cidrs`, `ingress_prefix_lists`, `ingress_security_groups`, `access_log_*`, `available_availability_zone_ids`, `resource_group_*` — and the only two hits were the two shown above. In particular this example sets **no** TLS attributes anywhere (its HTTPS listener is commented out), so the silent `tls_*` trap does not apply. Both listener elements (the live HTTP one and the commented HTTPS one) already carry `default_action_parameters`, so the newly-required attribute is satisfied. `module.alb.arn` is the only output this example consumes and it is unchanged.

### 3. `tedilabs/network/aws//modules/security-group` v0.27.0 → v1.2.3

**Verdict: ACTION_REQUIRED.**

Compare URL: https://github.com/tedilabs/terraform-aws-network/compare/v0.27.0...v1.2.3

This crosses two breaking waves: the rule redesign in **v0.31.0** (PR #57, *"Refactor security-group module"*) and the `resource_group_*` collapse in **v1.0.0** (PR #76).

- **Removed variables:** `name_prefix` — **no replacement**, callers must supply a concrete `name`. Plus `resource_group_enabled` / `resource_group_name` / `resource_group_description` (→ `resource_group` object).
- **Added variables:** `region`, `vpc_associations`, `resource_group`, `shares`. **No newly-required variable** — the required set is still just `name` and `vpc_id`.
- **Retyped/renamed:** `ingress_rules` / `egress_rules` went from `any` to a strict `list(object(...))`, with four per-rule attribute renames: `cidr_blocks`→`ipv4_cidrs`, `ipv6_cidr_blocks`→`ipv6_cidrs`, `prefix_list_ids`→`prefix_lists`, and `source_security_group_id` (`string`) → `security_groups` (`list(string)`). `from_port`/`to_port` became `optional(number)` and **must be omitted when `protocol = "-1"`**. A new validation requires at least one of `ipv4_cidrs` / `ipv6_cidrs` / `prefix_lists` / `security_groups` / `self` per rule. Because the type is now closed, all of this errors loudly at plan time.
- **Outputs:** nothing removed or renamed — `id`, `arn`, `name`, `owner_id`, `vpc_id` all still exist. Added: `region`, `description`, `ingress_rules`, `egress_rules`, `vpc_associations`, `resource_group`, `sharing`.
- **Version floors:** Terraform `>= 1.2` → `>= 1.12`; `hashicorp/aws` `>= 3.45` → `>= 6.12` (three provider majors).

Calling code changed in `examples/reachability-analyzer/main.tf`:

```diff
   ingress_rules = [
     {
-      id          = "http/all"
-      protocol    = "tcp"
-      from_port   = 80
-      to_port     = 80
-      cidr_blocks = ["0.0.0.0/0"]
+      id         = "http/all"
+      protocol   = "tcp"
+      from_port  = 80
+      to_port    = 80
+      ipv4_cidrs = ["0.0.0.0/0"]
     }
   ]
   egress_rules = [
     {
-      id          = "all/all"
-      protocol    = "-1"
-      from_port   = 0
-      to_port     = 0
-      cidr_blocks = ["0.0.0.0/0"]
+      id         = "all/all"
+      protocol   = "-1"
+      ipv4_cidrs = ["0.0.0.0/0"]
     }
   ]
```

This example used neither `name_prefix` nor `resource_group_*`, and consumes only `module.security_group.id`, so no further edits were needed.

**Note for real (non-example) callers of this security-group module:** the transition is destructive. v0.27.0 managed rules as `aws_security_group_rule.ingress["<id>"]` / `.egress["<id>"]`; v1.2.3 manages them as `aws_vpc_security_group_ingress_rule.this[...]` / `aws_vpc_security_group_egress_rule.this[...]`, fanning out to one resource per CIDR / prefix list / security group with keys like `"https/ipv4/0"`. **No `moved` blocks were added for the resource-type change**, so Terraform plans a full destroy of the old rule instances and a create of the new ones. The security group itself stays in state but now carries `lifecycle { create_before_destroy = true }`. Anyone applying this against a security group that protects live traffic should pre-seed with `terraform state mv` / `import` blocks, or accept a brief window with no rules.

### 4. `tedilabs/vpc-connectivity/aws` self-references (commented) `~> 0.1.0` / `~> 0.2.0` → `~> 0.9.0`

These are documentation-only comment lines inside `examples/`; the active `source` in each example is the local `../../modules/x` path. No interface consideration applies — they simply pointed at a version far behind this repo's current `v0.9.0`.

## Verification

- `terraform fmt -recursive -check .` — **pass** (clean, no reformatting needed).
- `modules/lattice-service` — `terraform init -backend=false -upgrade` + `terraform validate`: **pass**. Init resolved `tedilabs/organization/aws` **0.7.5** for `~> 0.7.0`, confirming the new constraint resolves against the public registry and the new `resources` map / `resource_group` object arguments type-check.
- `modules/lattice-service-network` — same: **pass**, same resolved version.
- `examples/lattice-alb-target-group` — `terraform init -backend=false -upgrade` resolved all child modules successfully, but **provider selection fails as committed**: the example's own `versions.tf` pins `hashicorp/aws = "~> 5.0"`, and ALB v1.5.0 requires `>= 6.22`, giving `no available releases match the given constraints ~> 5.0, >= 6.22.0, ...`. To actually prove the interface fix, the pin was **temporarily** relaxed to `~> 6.0` in the working tree, `terraform init` + `terraform validate` were run (**pass**, aws v6.58.0), and the file was then reverted with `git checkout`. `versions.tf` is unchanged in this PR — see follow-ups.
- `examples/reachability-analyzer` — identical situation (its pin is `~> 4.0`, security-group v1.2.3 needs `>= 6.12`). Validated the same way with a temporary `~> 6.0` relaxation: **pass**. `versions.tf` unchanged in this PR.
- Cleaned up `.terraform/` and `.terraform.lock.hcl` in every directory that was initialised; `git status --porcelain` was verified clean of build artefacts before committing.
- **Not verified:** no `terraform plan` or `apply` was run anywhere, so the destroy/recreate churn described above is inferred from the child modules' source (`for_each` keys and resource types), not observed in a real plan. The two example roots cannot be validated as committed for the provider-floor reason above.
- **Not verified:** the ALB `listeners` silent-failure class can only be checked by inspection, since `var.listeners` is typed `any`. This was done by grep (no `tls_*` keys present; `default_action_parameters` present on every element) rather than by the type checker.

### Known follow-ups (deliberately out of scope here)

1. **Provider/Terraform floors are short of what the new child modules require.** `modules/lattice-service/versions.tf` and `modules/lattice-service-network/versions.tf` both declare `required_version = ">= 1.5"` and `aws >= 5.21`, but the new `organization//modules/ram-share` requires `>= 1.12` / `aws >= 6.12`. `terraform init` still succeeds because Terraform resolves the intersection of all constraints, so this is an under-declaration rather than a break — but the floors should be raised in a dedicated PR.
2. Likewise, all six `examples/*/versions.tf` pin `aws` to `~> 4.0` or `~> 5.0` with `required_version = "~> 1.5"`. The two examples touched here need `aws ~> 6.0` (`>= 6.22` for ALB, `>= 6.12` for security-group) before they can be `init`ed as-is. Raising them is a provider-major upgrade and belongs in its own PR.
3. The `module_share` row in `modules/lattice-service/README.md` and `modules/lattice-service-network/README.md` was hand-edited rather than regenerated with `terraform-docs`, because a full regeneration produced substantial unrelated churn (markdown table separator style, provider version rows) and would have swept in a pre-existing staleness — both READMEs still list `resource-group` as `~> 0.10.0` while the `.tf` files say `~> 0.12.0`. A separate docs-regeneration pass should fix that.
4. `modules/lattice-service-network/ram-share.tf` and `modules/lattice-service/ram-share.tf` do **not** pass `region` to the child module, unlike the sibling repos (which pass `var.region` or `aws_*.this.region`). Neither module has a `region` variable yet, and the child module's `region` defaults to `null` (provider region), so behaviour is unchanged. Adding `region` support belongs with the provider-6 upgrade in follow-up 1.

## Supersedes

- **#76** — `chore(deps): update tedilabs/account/aws requirement from ~> 0.27.0 to ~> 0.33.10 in /modules/lattice-service`
- **#77** — `chore(deps): update tedilabs/account/aws requirement from ~> 0.27.0 to ~> 0.33.10 in /modules/lattice-service-network`

**Both of these dependabot PRs are broken, not merely non-conventional.** They are not the usual "dependabot pinned the exact patch instead of the house minor floor" case. They bump `tedilabs/account/aws` to `~> 0.33.10` on a `source` of `tedilabs/account/aws//modules/ram-share` — and **that submodule does not exist at any `0.29.x`+ version**, having been deleted in v0.29.0 by commit `e8e500a` and moved to `terraform-aws-organization`. Merging either one makes `terraform init` fail for the affected module with a "module not found" error. Dependabot cannot see this because it resolves the top-level registry module version, not the `//modules/<x>` subpath.

This PR supersedes both by migrating to the actual replacement, `tedilabs/organization/aws//modules/ram-share ~> 0.7.0`, and adapting the call sites. Neither PR has been closed.
