### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/lattice-alb-target-group/versions.tf
+++ b/examples/lattice-alb-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/lattice-instance-target-group/versions.tf
+++ b/examples/lattice-instance-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/lattice-ip-target-group/versions.tf
+++ b/examples/lattice-ip-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/lattice-lambda-target-group/versions.tf
+++ b/examples/lattice-lambda-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/lattice-service-network-simple/versions.tf
+++ b/examples/lattice-service-network-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/reachability-analyzer/versions.tf
+++ b/examples/reachability-analyzer/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

All 6 example roots in this repo pin an `aws` upper bound below what their own module graph
requires, so `terraform init` cannot resolve a provider and the examples are unusable as written.
Five pin `~> 5.0`, one pins `~> 4.0`. The binding lower bound is not declared locally — it arrives
transitively via `tedilabs/misc/aws//modules/resource-group@v0.12.0`, which requires `aws >= 6.0`.

Verbatim, from `examples/reachability-analyzer` on `main`:

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
hashicorp/aws: no available releases match the given constraints >= 3.45.0,
~> 4.0, >= 4.14.0, >= 4.58.0, >= 6.0.0, >= 6.12.0, >= 6.33.0
```

This PR raises the constraints so the examples resolve again. It touches only
`examples/*/versions.tf`.

## Convention applied

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `~> 6.0`

`~> 6.0` is sufficient even though parts of the graph declare `>= 6.12` and `>= 6.33`: Terraform
intersects all constraints, so `~> 6.0` ∩ `>= 6.33` = `[6.33, 7.0)`. Those module floors are
deliberately not copied into the roots. All 6 roots resolved to `hashicorp/aws` v6.58.0.

## Changed roots

| Example root | `required_version` before → after | `aws` before → after | Why |
| --- | --- | --- | --- |
| `examples/lattice-alb-target-group` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — graph needs `>= 6.0` |
| `examples/lattice-instance-target-group` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — graph needs `>= 6.33` |
| `examples/lattice-ip-target-group` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — graph needs `>= 6.0` |
| `examples/lattice-lambda-target-group` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — graph needs `>= 6.0` |
| `examples/lattice-service-network-simple` | `~> 1.5` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict — graph needs `>= 6.0` |
| `examples/reachability-analyzer` | `~> 1.5` → `~> 1.12` | `~> 4.0` → `~> 6.0` | conflict — graph needs `>= 6.33` |

6 init-breaking conflicts, 0 style-only violations.

## Verification

`terraform fmt -recursive -check .` — passes.

Per root, with an isolated `TF_PLUGIN_CACHE_DIR`, run serially,
`terraform init -backend=false && terraform validate`:

| Example root | Result |
| --- | --- |
| `examples/lattice-alb-target-group` | init OK, validate OK |
| `examples/lattice-instance-target-group` | init OK, validate OK |
| `examples/lattice-ip-target-group` | init OK, validate OK |
| `examples/lattice-lambda-target-group` | init OK, validate OK (1 warning, see below) |
| `examples/lattice-service-network-simple` | init OK, validate OK |
| `examples/reachability-analyzer` | init OK, validate OK |

`examples/lattice-lambda-target-group` validates successfully but emits one deprecation warning
originating inside a third-party registry module, not from this repo's code:

```
Warning: Deprecated value used

  on .terraform/modules/lambda_function/outputs.tf line 9, in output "lambda_function_arn_static":
The deprecation originates from module.lambda_function.data.aws_region.current.name
name is deprecated. Use region instead.
```

`.terraform/` and `.terraform.lock.hcl` were removed from every directory touched.

## Pre-existing failures newly exposed

**None.** This is a better outcome than anticipated and worth stating plainly.

`examples/lattice-alb-target-group` and `examples/reachability-analyzer` were expected to reach
`validate` and then fail on stale HCL, since the module-interface rewrites for those two roots live
in #78 (`examples/lattice-alb-target-group/alb.tf`, `examples/reachability-analyzer/main.tf`) and are
not on this branch. In practice both validate cleanly against this branch's HCL, so there is nothing
to hand off. Any remaining interface churn for those two roots is addressed by #78, not by this PR.

All 6 roots should be green in CI.

## Related PRs

Open PRs in this repo, and how they relate:

- **#78** `chore(deps): align tedilabs child module version constraints with latest releases`
  (`chore/deps-align-child-module-versions`) — rewrites example `main.tf`/`alb.tf` files for new
  module interfaces plus two `modules/**` files. It touches **no** `examples/*/versions.tf`.
  Confirmed with `git diff --name-only origin/main origin/chore/deps-align-child-module-versions`,
  which lists:

  ```
  examples/lattice-alb-target-group/alb.tf
  examples/lattice-alb-target-group/main.tf
  examples/lattice-instance-target-group/main.tf
  examples/lattice-ip-target-group/main.tf
  examples/lattice-lambda-target-group/main.tf
  examples/lattice-service-network-simple/main.tf
  examples/reachability-analyzer/main.tf
  modules/lattice-service-network/README.md
  modules/lattice-service-network/ram-share.tf
  modules/lattice-service/README.md
  modules/lattice-service/ram-share.tf
  ```

  The file sets are disjoint; the two PRs can merge in either order without conflict.
- **#77** / **#76** — dependabot bumps of the `tedilabs/account/aws` requirement, touching only
  `modules/lattice-service-network/ram-share.tf` and `modules/lattice-service/ram-share.tf`
  respectively. Both overlap with #78, not with this PR.
- **#64** `chore(deps): bump tj-actions/changed-files from 44 to 47` — dependabot; touches
  `.github/**`, `.editorconfig` and `README.md`. No `.tf` files.

There is no open `docs/align-readme-example-versions` PR in this repo.
